### PR TITLE
Update modes_funcs.cpp - 'modes_funcs'-'running' issue

### DIFF
--- a/src/modes_funcs.cpp
+++ b/src/modes_funcs.cpp
@@ -335,8 +335,8 @@ uint16_t WS2812FX::running(uint32_t color1, uint32_t color2) {
     setPixelColor(_seg->start, color);
   }
 
-  _seg_rt->counter_mode_step = (_seg_rt->counter_mode_step + 1) % _seg_len;
-  if(_seg_rt->counter_mode_step == 0) SET_CYCLE;
+  _seg_rt->counter_mode_step++;
+  if((_seg_rt->counter_mode_step % _seg_len) == 0) SET_CYCLE;
   return (_seg->speed / 16);
 }
 


### PR DESCRIPTION
If the length of the Segment is not a multiple of the length of the small segments the small segments are displayed sometimes with a wrong length. For example: with a Segment length of 60 LEDs and small segments set to ```SIZE_MEDIUM``` every 7th has a length of 8 LEDs, but all others are 4 LEDs, With ```SIZE_LARGE``` every 4th has a length of 4 LEDs, but all others are 8 LEDs.
This is because the parameter ```counter_mode_step``` resetted every ```_seg_len```.